### PR TITLE
Fixed DEV-20001 [KM][PCMT] Voice call: Patient can hear clinician in background, but clinician cannot hear patient until the app is reopened

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hrs-cordova-plugin-twilio",
-  "version": "3.0.3",
+  "version": "3.0.5",
   "description": "Use the Twilio Voice SDK for iOS or Android with Cordova/PhoneGap. Successor to Twilio Client Plugin",
   "scripts": {
     "version": "node ./scripts/version-sync.js"

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="hrs-cordova-plugin-twilio"
-    version="3.0.3">
+    version="3.0.5">
 
     <name>TwilioVoice</name>
     <description>Use the Twilio SDK for iOS or Android with Cordova. Based on the original plugin</description>
@@ -39,6 +39,11 @@
         <!-- <dependency id="phonegap-plugin-push"/> -->
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <service
+            android:name="com.phonegap.plugins.twiliovoice.AudioForegroundService"
+            android:foregroundServiceType="microphone"
+            android:enabled="true"
+            android:exported="false"/>
             <!-- [START fcm_listener] -->
             <!-- <service
                 android:name="com.phonegap.plugins.twiliovoice.fcm.VoiceFirebaseMessagingService">
@@ -78,6 +83,8 @@
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java"
                 target-dir="src/com/phonegap/plugins/twiliovoice" />
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/SoundPoolManager.java"
+                target-dir="src/com/phonegap/plugins/twiliovoice" />
+        <source-file src="src/android/com/phonegap/plugins/twiliovoice/AudioForegroundService.java"
                 target-dir="src/com/phonegap/plugins/twiliovoice" />
         <!-- <source-file src="src/android/com/phonegap/plugins/twiliovoice/fcm/VoiceFirebaseInstanceIDService.java"
                 target-dir="src/com/phonegap/plugins/twiliovoice/fcm" />

--- a/src/android/com/phonegap/plugins/twiliovoice/AudioForegroundService.java
+++ b/src/android/com/phonegap/plugins/twiliovoice/AudioForegroundService.java
@@ -1,0 +1,49 @@
+package com.phonegap.plugins.twiliovoice;
+
+import android.app.*;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import androidx.core.app.NotificationCompat;
+
+public class AudioForegroundService extends Service {
+
+    private static boolean isServiceRunning = false;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        isServiceRunning = true;
+        startForeground(1, createNotification());
+    }
+
+    public static boolean isRunning() {
+        return isServiceRunning;
+    }
+
+    private Notification createNotification() {
+        String channelId = "ForegroundServiceChannel";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                channelId, "Foreground Service", NotificationManager.IMPORTANCE_LOW);
+            getSystemService(NotificationManager.class).createNotificationChannel(channel);
+        }
+
+        return new NotificationCompat.Builder(this, channelId)
+            .setContentTitle("Voice call")
+            .setContentText("Voice call is in progress")
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .build();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        isServiceRunning = false;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java
+++ b/src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java
@@ -144,7 +144,9 @@ public class TwilioVoicePlugin extends CordovaPlugin {
             @Override
             public void onConnected(Call call) {
                 mCall = call;
-
+                Log.d(TAG, "On twilio call connected");
+                Intent serviceIntent = new Intent(cordova.getActivity(), AudioForegroundService.class);
+                cordova.getActivity().startForegroundService(serviceIntent);
                 JSONObject callProperties = new JSONObject();
                 try {
                     callProperties.putOpt("from", call.getFrom());
@@ -161,6 +163,8 @@ public class TwilioVoicePlugin extends CordovaPlugin {
             @Override
             public void onDisconnected(Call call, CallException exception) {
                 mCall = null;
+                Log.d(TAG, "On Twilio call disconnected");
+                stopForegroundService();
                 setAudioFocus(false);
                 javascriptCallback("oncalldiddisconnect", mInitCallbackContext);
             }
@@ -312,6 +316,16 @@ public class TwilioVoicePlugin extends CordovaPlugin {
         javascriptCallback("onclientinitialized", mInitCallbackContext);
     }
 
+    private void stopForegroundService() {
+        if(AudioForegroundService.isRunning()) {
+            Log.d(TAG, "Stopping audio foreground service");
+            Intent serviceIntent = new Intent(cordova.getActivity(), AudioForegroundService.class);
+            cordova.getActivity().stopService(serviceIntent);
+        } else {
+            Log.d(TAG, "Audio foreground service is not running");
+        }
+    }
+
     private void call(final JSONArray arguments, final CallbackContext callbackContext) {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
@@ -376,11 +390,13 @@ public class TwilioVoicePlugin extends CordovaPlugin {
         if (mCall == null) {
             callbackContext.sendPluginResult(new PluginResult(
                     PluginResult.Status.ERROR));
+            stopForegroundService();
             return;
         }
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 mCall.disconnect();
+                stopForegroundService();
                 callbackContext.success();
             }
         });
@@ -450,6 +466,7 @@ public class TwilioVoicePlugin extends CordovaPlugin {
         if (state == null) {
             state = "";
         }
+
         PluginResult result = new PluginResult(PluginResult.Status.OK, state);
         callbackContext.sendPluginResult(result);
     }
@@ -597,6 +614,7 @@ public class TwilioVoicePlugin extends CordovaPlugin {
         SoundPoolManager.getInstance(cordova.getActivity()).release();
         // LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(cordova.getActivity());
         // lbm.unregisterReceiver(mBroadcastReceiver);
+        stopForegroundService();
         super.onDestroy();
     }
 

--- a/src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java
+++ b/src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java
@@ -145,8 +145,10 @@ public class TwilioVoicePlugin extends CordovaPlugin {
             public void onConnected(Call call) {
                 mCall = call;
                 Log.d(TAG, "On twilio call connected");
-                Intent serviceIntent = new Intent(cordova.getActivity(), AudioForegroundService.class);
-                cordova.getActivity().startForegroundService(serviceIntent);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    Intent serviceIntent = new Intent(cordova.getActivity(), AudioForegroundService.class);
+                    cordova.getActivity().startForegroundService(serviceIntent);
+                }
                 JSONObject callProperties = new JSONObject();
                 try {
                     callProperties.putOpt("from", call.getFrom());
@@ -317,12 +319,14 @@ public class TwilioVoicePlugin extends CordovaPlugin {
     }
 
     private void stopForegroundService() {
-        if(AudioForegroundService.isRunning()) {
-            Log.d(TAG, "Stopping audio foreground service");
-            Intent serviceIntent = new Intent(cordova.getActivity(), AudioForegroundService.class);
-            cordova.getActivity().stopService(serviceIntent);
-        } else {
-            Log.d(TAG, "Audio foreground service is not running");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (AudioForegroundService.isRunning()) {
+                Log.d(TAG, "Stopping audio foreground service");
+                Intent serviceIntent = new Intent(cordova.getActivity(), AudioForegroundService.class);
+                cordova.getActivity().stopService(serviceIntent);
+            } else {
+                Log.d(TAG, "Audio foreground service is not running");
+            }
         }
     }
 


### PR DESCRIPTION
When PCMT was put in background, patient was not audible to clinician for an ongoing twilio voice call. We had to enhance twilio plugin code and have used android's foreground service when the call starts. This will help to continue the audio calls even when the user is not directly interacting with the app. The service displays a notification that cannot be dismissed until the service stops.
Added AudioForegroundService and used it when call start and stopped it on call disconnected. 
