### PR TITLE
Fixed DEV-23638, DEV-23653, DEV-23654 : Twilio voice calls not working

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,8 +13,8 @@
     </js-module>
 
     <engines>
-      <engine name="cordova" version="12.0.1" />
-      <engine name="cordova-android" version="14.0.0" />
+      <engine name="cordova" version=">=12.0.0" />
+      <engine name="cordova-android" version=">=14.0.0" />
       <engine name="cordova-ios" version=">=5.0.0" />
     </engines>
 


### PR DESCRIPTION
Voice calls were not getting connected/handled as Twilio plugin code was not getting added in the build. Observed this message while building the code

_Discovered plugin "hrs-cordova-plugin-twilio". Adding it to the project Installing "hrs-cordova-plugin-twilio" for android
Plugin doesn't support this project's cordova version. cordova: 12.0.2, failed version requirement: 12.0.1
Skipping 'hrs-cordova-plugin-twilio' for android_

Changes to get the supported version added. 

Dev tested voice calls under these issues and they worked fine. 